### PR TITLE
build: update mapserverapi_python to fix failure at runtime

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -2,7 +2,7 @@
 | --- | --- | --- |
 | [mapserver](http://mapserver.org) | 7.4.2 | mapserver |
 | [mapserverapi](https://github.com/metwork-framework/mapserverapi) | 0.1.6 | mapserver |
-| [mapserverapi](https://github.com/metwork-framework/mapserverapi_python) | cafb8b4 | python2_mapserverapi |
-| [mapserverapi](https://github.com/metwork-framework/mapserverapi_python) | cafb8b4 | python3_mapserverapi |
+| [mapserverapi](https://github.com/metwork-framework/mapserverapi_python) | c90f709 | python2_mapserverapi |
+| [mapserverapi](https://github.com/metwork-framework/mapserverapi_python) | c90f709 | python3_mapserverapi |
 
 *(4 components)*

--- a/layers/layer3_mapserver/.system_dependencies
+++ b/layers/layer3_mapserver/.system_dependencies
@@ -1,2 +1,2 @@
+libglib-2.0.so.0()(64bit)@generic
 libXrender.so.1()(64bit)@generic
-libXrender@centos6,centos7

--- a/layers/layer4_python2_mapserverapi/0500_extra_packages/requirements2.txt
+++ b/layers/layer4_python2_mapserverapi/0500_extra_packages/requirements2.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/metwork-framework/mapserverapi_python.git@cafb8b4b0c24d2d954e701e55f283219a7e50354#egg=mapserverapi
+-e git+https://github.com/metwork-framework/mapserverapi_python.git@c90f709ac201d4aedce370d62091b99275dfd741#egg=mapserverapi

--- a/layers/layer4_python3_mapserverapi/0500_extra_packages/requirements3.txt
+++ b/layers/layer4_python3_mapserverapi/0500_extra_packages/requirements3.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/metwork-framework/mapserverapi_python.git@cafb8b4b0c24d2d954e701e55f283219a7e50354#egg=mapserverapi
+-e git+https://github.com/metwork-framework/mapserverapi_python.git@c90f709ac201d4aedce370d62091b99275dfd741#egg=mapserverapi


### PR DESCRIPTION
without glib2-devel since we do not build anymore glib2 in mfext